### PR TITLE
[FEAT] 검색페이지 이미지 배너 추가 및 분야별 변수 정의

### DIFF
--- a/frontend/src/constants/Image.js
+++ b/frontend/src/constants/Image.js
@@ -1,0 +1,16 @@
+const Image = {
+  ACADEMIC:
+    "https://cdn.pixabay.com/photo/2015/07/31/11/45/library-869061_640.jpg",
+  RELIGION:
+    "https://cdn.pixabay.com/photo/2014/10/22/18/16/church-498525_640.jpg",
+  SPORTS:
+    "https://cdn.pixabay.com/photo/2016/11/29/03/53/athletes-1867185_640.jpg",
+  AMITY:
+    "https://cdn.pixabay.com/photo/2019/10/01/12/24/nature-4518094_640.jpg",
+  CULTURE:
+    "https://cdn.pixabay.com/photo/2018/05/12/19/20/mosaic-3394375_640.jpg",
+  VOLUNTEER:
+    "https://cdn.pixabay.com/photo/2016/11/14/04/10/grandmother-1822564_640.jpg",
+};
+
+export default Image;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -22,7 +22,7 @@ root.render(
         <Route path="/" element={<MainPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignUpPage />} />
-        <Route path="/area" element={<AreaPage />} />
+        <Route path="/area/:field" element={<AreaPage />} />
         <Route path="/intro" element={<IntroPage />} />
         <Route path="/input" element={<InputPage />} />
         <Route path="/mypage" element={<MyPage />} />

--- a/frontend/src/pages/AreaPage.jsx
+++ b/frontend/src/pages/AreaPage.jsx
@@ -1,7 +1,43 @@
+import styled from "@emotion/styled";
 import React from "react";
+import { useParams } from "react-router-dom";
+import Header from "../components/Header";
+import Image from "../constants/Image";
 
 function AreaPage() {
-  return <>AreaPage</>;
+  const area = useParams().field;
+
+  const AreaContainer = styled.div`
+    display: flex;
+    width: 100%;
+    height: 100%;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  `;
+
+  const Banner = styled.img`
+    width: 90vw;
+    height: 300px;
+    border-radius: 10px;
+    border: none;
+  `;
+
+  return (
+    <AreaContainer>
+      <Header></Header>
+      <Banner src={getImgURL(area)} />
+    </AreaContainer>
+  );
 }
 
 export default AreaPage;
+
+export const getImgURL = (area) => {
+  if (area === "학술") return Image.ACADEMIC;
+  if (area === "종교") return Image.RELIGION;
+  if (area === "스포츠") return Image.SPORTS;
+  if (area === "친목") return Image.AMITY;
+  if (area === "문화") return Image.CULTURE;
+  if (area === "봉사") return Image.VOLUNTEER;
+};

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import styled from "@emotion/styled";
 import Header from "../components/Header";
 import { Link } from "react-router-dom";
+import Image from "../constants/Image.js";
+import { useState } from "react";
 
 function MainPage() {
   const MainContainer = styled.div`
@@ -60,42 +62,42 @@ function MainPage() {
       </TitleContainer>
 
       <ButtonWrapper>
-        <Link to="/area">
-          <FieldButton
-            url="https://cdn.pixabay.com/photo/2015/07/31/11/45/library-869061_640.jpg"
-            type="button"
-          />
+        <Link
+          to={{
+            pathname: `/area/학술`,
+          }}>
+          <FieldButton url={Image.ACADEMIC} type="button" />
         </Link>
 
-        <Link to="/area">
-          <FieldButton
-            url="https://cdn.pixabay.com/photo/2014/10/22/18/16/church-498525_640.jpg"
-            type="button"
-          />
+        <Link
+          to={{
+            pathname: `/area/종교`,
+          }}>
+          <FieldButton url={Image.RELIGION} type="button" />
         </Link>
-        <Link to="/area">
-          <FieldButton
-            url="https://cdn.pixabay.com/photo/2016/11/29/03/53/athletes-1867185_640.jpg"
-            type="button"
-          />
+        <Link
+          to={{
+            pathname: `/area/스포츠`,
+          }}>
+          <FieldButton url={Image.SPORTS} type="button" />
         </Link>
-        <Link to="/area">
-          <FieldButton
-            url="https://cdn.pixabay.com/photo/2019/10/01/12/24/nature-4518094_640.jpg"
-            type="button"
-          />
+        <Link
+          to={{
+            pathname: `/area/친목`,
+          }}>
+          <FieldButton url={Image.AMITY} type="button" />
         </Link>
-        <Link to="/area">
-          <FieldButton
-            url="https://cdn.pixabay.com/photo/2018/05/12/19/20/mosaic-3394375_640.jpg"
-            type="button"
-          />
+        <Link
+          to={{
+            pathname: `/area/문화`,
+          }}>
+          <FieldButton url={Image.CULTURE} type="button" />
         </Link>
-        <Link to="/area">
-          <FieldButton
-            url="https://cdn.pixabay.com/photo/2016/11/14/04/10/grandmother-1822564_640.jpg"
-            type="button"
-          />
+        <Link
+          to={{
+            pathname: `/area/봉사`,
+          }}>
+          <FieldButton url={Image.VOLUNTEER} type="button" />
         </Link>
       </ButtonWrapper>
     </MainContainer>


### PR DESCRIPTION
<img width="808" alt="image" src="https://github.com/Lim-JiSeon/HufsClub/assets/83554018/3ddddd86-5734-4176-a471-aab6c68e2eca">


이런식으로 URL에 분야 키워드를 보낼거라서 API 연동 때 field 를 이 키워드로 req 보낼께요!

<완료>
- 분야별 키워드 연동 작업
- 이미지 변수 선언 및 연동 작업
- url 조정 및 수정 작업

<이어서 작업할 일>
- api 연동
- 검색바 구현
