### PR TITLE
정보 수정 Controller 수정

### DIFF
--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -141,10 +141,10 @@ userRouter.put(
       user.email = req.body.email || user.email;
       user.isEnroll = req.body.isEnroll || user.isEnroll;
       user.isPresident = req.body.isPresident;
-      if (req.body.newPassword) {
+      if (req.body.password) { 
         //기존 비밀번호 일치 여부 확인
-        if (user.password == bcrypt.hashSync(req.body.password, 8)) {
-          user.password = bcrypt.hashSync(req.body.newPassword, 8);
+        if (bcrypt.compareSync(req.body.password, user.password)) {
+          user.password = bcrypt.hashSync(req.body.newPassword);
         } else { //기존 비밀번호 불일치
           return res.status(404).send({ message: 'Invalid existing password' });
         }

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -135,11 +135,20 @@ userRouter.put(
     const user = await User.findById(req.user._id);
     if (user) {
       user.username = req.body.username || user.username;
+      user.studentId = req.body.studentId || user.studentId; 
       user.major = req.body.major || user.major;
       user.major2 = req.body.major2;
       user.email = req.body.email || user.email;
       user.isEnroll = req.body.isEnroll || user.isEnroll;
       user.isPresident = req.body.isPresident;
+      if (req.body.newPassword) {
+        //기존 비밀번호 일치 여부 확인
+        if (user.password == bcrypt.hashSync(req.body.password, 8)) {
+          user.password = bcrypt.hashSync(req.body.newPassword, 8);
+        } else { //기존 비밀번호 불일치
+          return res.status(404).send({ message: 'Invalid existing password' });
+        }
+      }
 
       const updatedUser = await user.save();
       res.send({


### PR DESCRIPTION
- 정보 수정 Controller 및 API 명세서 수정(아이디(학번)와 비밀번호 수정 가능하도록 변경)
기존 비밀번호 입력 칸 밑에 추가 설명으로 '비밀번호 변경 시에만 입력하세요.'라고 설명이 있으면 좋을 것 같다. 왜냐하면 비밀번호를 수정할 때만 기존 비밀번호를 입력해야 하고 다른 정보를 수정할 때는 입력할 필요가 없기 때문이다.