### PR TITLE
마이페이지 기존 비밀번호 확인 api 추가

### DIFF
--- a/backend/models/userModel.js
+++ b/backend/models/userModel.js
@@ -13,6 +13,7 @@ const userSchema = new mongoose.Schema(
     isAdmin: { type: Boolean, required: true, default: false },
     like: [{ type: String, trim: true }],
     resetToken: { type: String },
+    checkToken: { type: String },
     verificationCode: { type: String },
   },
   {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",


### PR DESCRIPTION
#작업한 내용
- 사용자 정보 조회 res에 isPresident 변수 추가(명세서도 수정 완료)
- MyPage 기존 비밀번호 확인 api 추가(명세서도 작성 완료)
    userModel에 checkToken 변수 추가(checkToken: 유효 시간 3시간인 별개의 token, 비밀번호 확인 api의 응답으로 전달됨)

#작업할 내용
- 좋아요 추가 controller 및 api명세서 작성
- imageUrl, 활동 내용 excutiveSchema처럼 사진과 활동 묶어서 정보 4개
- 동아리 글 작성 버튼 누를 때 이미 글 존재하는지 검사
- 세부 동아리 정보 페이지에 수정 및 삭제 api 구현하기(회장 여부는 Front-end에서 검사)