### PR TITLE
아이디 가져오기 및 비밀번호 재설정

### DIFF
--- a/frontend/src/api/changePw.js
+++ b/frontend/src/api/changePw.js
@@ -1,0 +1,19 @@
+import axios from "axios";
+
+const changePw = async (token, password) => {
+  const API_END_POINT = "http://localhost:5000/api/";
+
+  return axios
+    .post(`${API_END_POINT}users/reset-password`, {
+      token: token,
+      password: password,
+    })
+    .then((res) => {
+      return res.data;
+    })
+    .catch((err) => {
+      return err;
+    });
+};
+
+export default changePw;

--- a/frontend/src/api/findId.js
+++ b/frontend/src/api/findId.js
@@ -3,18 +3,10 @@ import axios from "axios";
 const findId = (name, email) => {
   const API_END_POINT = "http://localhost:5000/api/";
 
-  console.log(name, email);
-  axios
-    .post(`${API_END_POINT}users/forget-id`, {
-      username: name, //"김철수",
-      email: email, //"rac8793@naver.com",
-    })
-    .then((res) => {
-      console.log(res);
-    })
-    .catch((err) => {
-      console.log(err);
-    });
+  return axios.post(`${API_END_POINT}users/forget-id`, {
+    username: name,
+    email: email,
+  });
 };
 
 export default findId;

--- a/frontend/src/api/findPw.js
+++ b/frontend/src/api/findPw.js
@@ -1,18 +1,17 @@
 import axios from "axios";
 
-const findPw = (email) => {
+const findPw =async (email) => {
   const API_END_POINT = "http://localhost:5000/api/";
 
-  console.log(email);
-  axios
+  return axios
     .post(`${API_END_POINT}users/forget-password`, {
-      email: email, //"rac8793@naver.com",
+      email: email,
     })
     .then((res) => {
-      console.log(res);
+      return res.data;
     })
     .catch((err) => {
-      console.log(err);
+      return err;
     });
 };
 

--- a/frontend/src/api/getId.js
+++ b/frontend/src/api/getId.js
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+const getId = async (email, verificationCode) => {
+  const API_END_POINT = "http://localhost:5000/api/";
+
+  const data = axios
+    .post(`${API_END_POINT}users/verify-verification-code`, {
+      email: email,
+      verificationCode: verificationCode,
+    })
+    .then((res) => {
+      return res.data;
+    })
+    .catch((error) => {
+      return error;
+    });
+  return data;
+};
+
+export default getId;

--- a/frontend/src/components/FindIdForm.js
+++ b/frontend/src/components/FindIdForm.js
@@ -6,6 +6,8 @@ import CardForm from "./CardForm";
 import Title from "./TopicTitle";
 import styled from "@emotion/styled";
 import findId from "../api/findId";
+import { useState } from "react";
+import getId from "../api/getId";
 
 const EmailWrap = styled.div`
   display: flex;
@@ -22,23 +24,22 @@ const SendEmail = styled.button`
   cursor: pointer;
 `;
 
-const FindIdForm = ({ onSubmit }) => {
-  const checkNum = /^[0-9]+$/;
-  const { values, errors, isLoading, handleChange, handleLogin } = useForm({
+const FindIdForm = () => {
+  const [notificationEmail, setNotificationEmail] = useState("");
+  const { values, errors, isLoading, handleChange } = useForm({
     initialValues: {
       name: "",
       email: "",
-      codeNumber: "",
-    },
-    onSubmit,
-    validate: ({ id, password }) => {
-      const newErrors = {};
-      if (!id || id.length !== 9 || !checkNum.test(id))
-        newErrors.id = "올바른 아이디를 입력해주세요";
-      if (!password) newErrors.password = "비밀번호를 입력해주세요";
-      return newErrors;
+      verificationCode: "",
     },
   });
+
+  const submitId = async () => {
+    const { message, studentId } = await getId(
+      values.email,
+      values.verificationCode
+    );
+  };
 
   return (
     <CardForm>
@@ -55,18 +56,20 @@ const FindIdForm = ({ onSubmit }) => {
         {errors.id && <ErrorText>{errors.id}</ErrorText>}
         <SendEmail
           type="button"
-          onClick={() => findId(values.name, values.email)}>
+          onClick={() =>
+            setNotificationEmail(findId(values.name, values.email))
+          }>
           인증번호 받기
         </SendEmail>
       </EmailWrap>
       <Input
-        type="number"
-        name="codeNumber"
+        type="text"
+        name="verificationCode"
         onChange={handleChange}
         label="인증번호"
       />
       {errors.id && <ErrorText>{errors.id}</ErrorText>}
-      <Button type="button" disabled={isLoading}>
+      <Button type="button" disabled={isLoading} onClick={submitId}>
         아이디 찾기
       </Button>
     </CardForm>

--- a/frontend/src/components/FindPwForm.js
+++ b/frontend/src/components/FindPwForm.js
@@ -5,29 +5,25 @@ import Input from "./func/Input";
 import CardForm from "./CardForm";
 import Title from "./TopicTitle";
 import findPw from "../api/findPw";
+import { useState } from "react";
 
-const FindPwForm = ({ onSubmit }) => {
-  const checkNum = /^[0-9]+$/;
-  const { values, errors, isLoading, handleChange, handleLogin } = useForm({
+const FindPwForm = () => {
+  const [notification, setNotification] = useState("");
+  const { values, errors, isLoading, handleChange } = useForm({
     initialValues: {
       email: "",
-    },
-    onSubmit,
-    validate: ({ id, password }) => {
-      const newErrors = {};
-      if (!id || id.length !== 9 || !checkNum.test(id))
-        newErrors.id = "올바른 아이디를 입력해주세요";
-      if (!password) newErrors.password = "비밀번호를 입력해주세요";
-      return newErrors;
     },
   });
 
   return (
-    <CardForm onSubmit={findPw(values.email)}>
+    <CardForm>
       <Title>비밀번호 찾기</Title>
       <Input type="email" name="email" onChange={handleChange} label="이메일" />
       {errors.id && <ErrorText>{errors.id}</ErrorText>}
-      <Button type="submit" disabled={isLoading}>
+      <Button
+        type="button"
+        disabled={isLoading}
+        onClick={async () => setNotification(await findPw(values.email))}>
         비밀번호 찾기
       </Button>
     </CardForm>

--- a/frontend/src/components/ResetPwForm.js
+++ b/frontend/src/components/ResetPwForm.js
@@ -1,0 +1,50 @@
+import useForm from "../hooks/useForm";
+import Button from "./SubmitButton";
+import ErrorText from "./errors/ErrorText";
+import Input from "./func/Input";
+import CardForm from "./CardForm";
+import Title from "./TopicTitle";
+import findPw from "../api/findPw";
+import { useState } from "react";
+import changePw from "../api/changePw";
+import { useLocation } from "react-router-dom";
+
+const ResetPwForm = () => {
+  const [notification, setNotification] = useState("");
+  const token = useLocation().pathname.split("/")[2];
+  const { values, errors, isLoading, handleChange } = useForm({
+    initialValues: {
+      password: "",
+    },
+  });
+
+  return (
+    <CardForm>
+      <Title>비밀번호 재설정</Title>
+      <Input
+        type="text"
+        name="password"
+        onChange={handleChange}
+        label="비밀번호"
+      />
+      {errors.id && <ErrorText>{errors.id}</ErrorText>}
+      <Input
+        type="password"
+        name="passwordConfirm"
+        onChange={handleChange}
+        label="비밀번호 확인"
+      />
+      {errors.id && <ErrorText>{errors.id}</ErrorText>}
+      <Button
+        type="button"
+        disabled={isLoading}
+        onClick={async () =>
+          setNotification(await changePw(token, values.password))
+        }>
+        비밀번호 변경하기
+      </Button>
+    </CardForm>
+  );
+};
+
+export default ResetPwForm;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -15,6 +15,7 @@ import MyPage from "./pages/MyPage";
 import NotPage from "./pages/NotPage";
 import FindIdPage from "./pages/FindIdPage";
 import FindPwPage from "./pages/FindPwPage";
+import ResetPwPage from "./pages/ResetPwPage";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
@@ -30,6 +31,7 @@ root.render(
         <Route path="/intro" element={<IntroPage />} />
         <Route path="/input" element={<InputPage />} />
         <Route path="/mypage" element={<MyPage />} />
+        <Route path="/reset-password/:codeNumber" element={<ResetPwPage />} />
         <Route path="*" element={<NotPage />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/FindIdPage.jsx
+++ b/frontend/src/pages/FindIdPage.jsx
@@ -21,7 +21,7 @@ function FindIdPage() {
     <Wrapper>
       <Header></Header>
       <FormWrapper>
-        <FindIdForm onSubmit />
+        <FindIdForm />
       </FormWrapper>
     </Wrapper>
   );

--- a/frontend/src/pages/ResetPwPage.jsx
+++ b/frontend/src/pages/ResetPwPage.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "@emotion/styled";
-import FindPwForm from "../components/FindPwForm";
+import ResetPwForm from "../components/ResetPwForm";
 import Header from "../components/Header";
 
 const Wrapper = styled.div`
@@ -16,15 +16,15 @@ const FormWrapper = styled.div`
   padding: 50px 0;
 `;
 
-function FindPwPage() {
+function ResetPwPage() {
   return (
     <Wrapper>
       <Header></Header>
       <FormWrapper>
-        <FindPwForm />
+        <ResetPwForm />
       </FormWrapper>
     </Wrapper>
   );
 }
 
-export default FindPwPage;
+export default ResetPwPage;


### PR DESCRIPTION
- 이메일에서 받은 인증번호를 입력할 경우 아이디를 가져오는 로직을 추가했습니다.
- 비밀번호를 리셋하는 링크를 이메일로 받을 경우 그 링크를 통한 페이지 전환 작업을 진행했습니다.
- 비밀번호 재설정 페이지를 만들었습니다.

추가 작업
- 이메일 양식 의논하기(우선순위 낮음)
- 자잘한 알림 창들 작업하기(이부분은 우선순위가 낮기 때문에 추후 작업)


이메일 아이디 인증번호
<img width="1079" alt="image" src="https://github.com/Lim-JiSeon/HufsClub/assets/83554018/7466a3df-f807-4021-8979-406144175ee9">



이메일 리셋 
<img width="1082" alt="image" src="https://github.com/Lim-JiSeon/HufsClub/assets/83554018/985ce5ad-d6a3-4986-8f60-73d10b258dc3">
