### PR TITLE
좋아요 삭제&동아리 글 작성 및 수정

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -10,7 +10,9 @@ const data = {
         major2: '통계학부',
         password: bcrypt.hashSync('123456'),
         isEnroll: '재학',
+        isPresident: 'PnP',
         isAdmin: true,
+        like: ['PnP', '그누빌'],
         },
     {
         username: '홍길동',
@@ -20,7 +22,7 @@ const data = {
         major2: '통계학부',
         password: bcrypt.hashSync('123456'),
         isEnroll: '졸업',
-        isPresident: '오징어심리연구',
+        isPresident: '별하',
         like: ['PnP', '피버스'],
     },
   ],

--- a/backend/data.js
+++ b/backend/data.js
@@ -22,7 +22,7 @@ const data = {
         major2: '통계학부',
         password: bcrypt.hashSync('123456'),
         isEnroll: '졸업',
-        isPresident: '별하',
+        isPresident: 'PnP',
         like: ['PnP', '피버스'],
     },
   ],

--- a/backend/models/clubModel.js
+++ b/backend/models/clubModel.js
@@ -40,7 +40,7 @@ const clubSchema = new mongoose.Schema(
 clubSchema.static("formatHashtags", function (hashtags) {
   return hashtags
     .split(',')
-    .map((word) => (word.startsWith("#")) ? word : `#${word}`);
+    .map((word) => (word.trim().startsWith("#")) ? word.trim() : `#${word.trim()}`);
 });
 
 const Club = mongoose.model('Club', clubSchema);

--- a/backend/routes/clubRoutes.js
+++ b/backend/routes/clubRoutes.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import expressAsyncHandler from 'express-async-handler';
+import User from '../models/userModel.js';
 import Club from '../models/clubModel.js';
 import { isAuth, isAdmin, isPresidentOrAdmin } from '../utili.js';
 
@@ -74,24 +75,41 @@ clubRouter.get('/:id', async (req, res) => {
     res.status(404).send({ message: 'Club Not Found' });
   }
 });
-/*
+
+//동아리 글 중복 검사
+clubRouter.get(
+  '/write/check', 
+  isAuth,
+  expressAsyncHandler(async (req, res) => {
+    const user = await User.findById(req.user._id);
+    if (user.isAdmin && !user.isPresident) { //관리자이면서 동아리 회장이 아닌 경우
+      res.send({ message: 'Admin User' });
+    } else {
+      const club = await Club.find({ name: user.isPresident });
+      if(club.length !== 0){
+        res.status(404).send({ message: 'Club Already Exists' });
+      } else {
+        res.send({ message: 'New Writing Available' });
+      }
+    }
+  })
+);
+
 //동아리 글 작성
 clubRouter.post(
   '/',
   isAuth,
-  isPresidentOrAdmin,
   expressAsyncHandler(async (req, res) => {
+    const user = await User.findById(req.user._id);
     const newClub = new Club({
-      name: 'sample name ' + Date.now(),
-      slug: 'sample-name-' + Date.now(),
-      image: '/images/p1.jpg',
-      price: 0,
-      category: 'sample category',
-      brand: 'sample brand',
-      countInStock: 0,
-      rating: 0,
-      numReviews: 0,
-      description: 'sample description',
+      name: (user.isAdmin)? req.body.name : user.isPresident, 
+      field: req.body.field,
+      topic: (req.body.topic)? Club.formatHashtags(req.body.topic) : req.body.topic,
+      executive: req.body.executive,
+      activity: req.body.activity,
+      recruit: req.body.recruit,
+      room: req.body.room,
+      logoUrl: req.body.logoUrl,
     });
     const club = await newClub.save();
     res.send({ message: 'Club Created', club });
@@ -99,35 +117,37 @@ clubRouter.post(
 );
 
 //동아리 글 수정
-//동아리 글 삭제(사용자의 like에서도 삭제되어야 함.)
 clubRouter.put(
   '/:id',
   isAuth,
-  isAdmin,
   expressAsyncHandler(async (req, res) => {
+    const user = await User.findById(req.user._id);
     const clubId = req.params.id;
     const club = await Club.findById(clubId);
     if (club) {
-      club.name = req.body.name;
-      club.slug = req.body.slug;
-      club.price = req.body.price;
-      club.image = req.body.image;
-      club.images = req.body.images;
-      club.category = req.body.category;
-      club.brand = req.body.brand;
-      club.countInStock = req.body.countInStock;
-      club.description = req.body.description;
-      await club.save();
-      res.send({ message: 'Club Updated' });
+      if (user.isAdmin || user.isPresident === club.name) {
+        club.name = ((user.isAdmin)? req.body.name : user.isPresident) || club.name, 
+        club.field = req.body.field || club.field,
+        club.topic = (req.body.topic)? Club.formatHashtags(req.body.topic) : req.body.topic,
+        club.executive = req.body.executive,
+        club.activity = req.body.activity,
+        club.recruit = req.body.recruit,
+        club.room = req.body.room,
+        club.logoUrl = req.body.logoUrl,
+        await club.save();
+        res.send({ message: 'Club Updated', club });
+      } else {
+        res.status(404).send( { message: 'Neither President of this club nor Admin' });
+      }
     } else {
       res.status(404).send({ message: 'Club Not Found' });
     }
   })
 );
-
+/*
+//동아리 글 삭제(사용자의 like에서도 삭제되어야 함.)
 clubRouter.delete(
   '/:id',
-  isAuth,
   isAdmin,
   expressAsyncHandler(async (req, res) => {
     const club = await Club.findById(req.params.id);

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -381,6 +381,36 @@ userRouter.put(
   })
 );
 
+//좋아요 삭제
+userRouter.put(
+  '/dislike',
+  isAuth,
+  expressAsyncHandler(async (req, res) => {
+    const user = await User.findById(req.user._id);
+    if (user) {
+      let filtered = user.like.filter((element) => element != req.body.clubname);
+      user.like = filtered;
+
+      const updatedUser = await user.save();
+      res.send({
+        _id: updatedUser._id,
+        username: updatedUser.username,
+        email: updatedUser.email,
+        studentId: updatedUser.studentId,
+        major: updatedUser.major,
+        major2: updatedUser.major2,
+        isEnroll: updatedUser.isEnroll,
+        isPresident: updatedUser.isPresident,
+        isAdmin: updatedUser.isAdmin,
+        like: updatedUser.like,
+        token: generateToken(updatedUser),
+      });
+    } else {
+      return res.status(404).send({ message: 'User not found' });
+    }
+  })
+);
+
 //사용자 정보 수정(관리자용)
 userRouter.put(
   '/:id',


### PR DESCRIPTION
#작업한 내용
- 좋아요 삭제 controller 및 API 명세서 작성
- 동아리 글 작성 버튼 누를 때 해당 글이 이미 존재하는지 검사하는 글 중복 검사 controller 및 API 명세서 작성

- 동아리 글 작성&수정 controller 공통 사항
     *동아리 글 작성자가 관리자일 경우 동아리 이름(name)을 직접 입력할 수 있지만(req로 name을 받음), 회장일  경우 name 
      은 user의 isPresident 변수의 내용으로 자동 설정되도록 했습니다.(회장일 경우 req로 name을 보낼 필요 없음. req로 name 
      을 보내더라도 isPresident의 내용으로 name이 설정됨)        
     *topic은 사용자가 쉼표로 구분해 입력하면 백엔드에서 해쉬태그 적용해서 DB에 저장합니다.
     (*에 대한 자세한 내용은 Postman 예시 참고해주세요!)

- 동아리 글 작성 controller 및 API 명세서 작성
- 동아리 글 수정 controller 및 API 명세서 작성
  * 해당 동아리 글의 회장이거나 관리자인지는 프론트에서 검사한다. 백엔드에서도 검사하긴 하지만, 권한이 없을 경우 아예 수정 페이지에 들어가지 못하게 하는 것이 맞을 것 같다. 백엔드의 검사 로직은 수정할 내용을 다 작성하고 최종적으로 수정하기 버튼을 눌렀을 때 동작하기 때문에...
  * field는 필수 입력 정보이므로 req값이 오지 않으면 기존(이전)의 정보를 적용.


#작업할 내용
- 동아리 글 삭제 controller 및 API 명세서 작성(관리자 및 회장 여부는 프론트에서 검사)