### PR TITLE
헤더 : 로그인 시 헤더 변경 및 로그아웃 로직 추가

### DIFF
--- a/frontend/src/components/Avatar.js
+++ b/frontend/src/components/Avatar.js
@@ -1,11 +1,7 @@
 import Image from "./func/Image";
-import { useState } from "react";
-import Dropdown from "./Dropdown";
 import styled from "@emotion/styled";
 
 function Avatar() {
-  const [dropdownView, setDropdownView] = useState(false);
-
   const ProfileButton = styled.div`
     position: relative;
   `
@@ -19,11 +15,7 @@ function Avatar() {
         height={50}
         borderRadius={50}
         style={{position: "absolute"}}
-        onClick={() => {
-          setDropdownView(!dropdownView);
-        }}
       />
-      {dropdownView && <Dropdown />}
     </ProfileButton>
   );
 }

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -5,10 +5,16 @@ import { Link } from "react-router-dom";
 import Avatar from "./Avatar";
 
 const Header = () => {
-  const isLogin = sessionStorage.getItem("isLogin") ?? "";
+  const isLogin = sessionStorage.getItem("hufs-club_isLogin") ?? "";
 
   const Header = styled.div`
     display: flex;
+    align-items: center;
+  `;
+
+  const AvatarWrap = styled.div`
+    display: flex;
+    justify-content: space-around;
     align-items: center;
   `;
 
@@ -39,6 +45,11 @@ const Header = () => {
     }
   `;
 
+  const logout = () => {
+    sessionStorage.setItem("hufs-club_isLogin", "");
+    window.location.reload();
+  };
+
   return (
     <Header>
       <HomeButton isLogin={isLogin}>
@@ -47,7 +58,14 @@ const Header = () => {
         </Link>
       </HomeButton>
       {isLogin ? (
-        <Avatar />
+        <AvatarWrap>
+          <Link to="/mypage">
+            <Avatar />
+          </Link>
+          <Link to="/">
+            <SignButton onClick={logout}>로그아웃</SignButton>
+          </Link>
+        </AvatarWrap>
       ) : (
         <SignButtonContainer isLogin={isLogin}>
           <Link to="/login">


### PR DESCRIPTION
구현 내용
- token 유무로 로그인 여부를 구분했습니다.
- 그에 따라 header를 다르게 보이게 설정했습니다.
- 임시로 프로필 이미지와 로그아웃 버튼을 만들었으며, 프로필 클릭 시 마이페이지로 이동합니다.

로그인 했을 때
<img width="1084" alt="image" src="https://github.com/Lim-JiSeon/HufsClub/assets/83554018/4d60b4fd-c7ef-40e2-b83b-6dd2c7683365">

로그인을 하지 않았을 때
<img width="1051" alt="image" src="https://github.com/Lim-JiSeon/HufsClub/assets/83554018/ea5245d6-3bf9-4cf8-af27-0b1dba044135">
