### PR TITLE
동아리 검색 : 검색 페이지 구현 완료

### DIFF
--- a/frontend/src/components/ClubGrid.js
+++ b/frontend/src/components/ClubGrid.js
@@ -8,14 +8,21 @@ const GridWrap = styled.div`
   border-radius: 20px;
   border: solid 2px #27374d;
   margin-bottom: 20px;
+  padding: 30px;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  place-items: center;
+  gap: 10px;
 `;
 
 const ClubGrid = (data) => {
   const clubs = data.data.data;
-  console.log(clubs);
+ 
   return (
     <GridWrap>
-      {clubs && clubs.map((club) => <ClubItem data={club} />)}
+      {clubs
+        ? clubs.map((club) => <ClubItem key={club._id} data={club} />)
+        : null}
     </GridWrap>
   );
 };

--- a/frontend/src/components/func/ClubItem.js
+++ b/frontend/src/components/func/ClubItem.js
@@ -1,14 +1,62 @@
+import styled from "@emotion/styled";
+import { Link } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+
+const CardItemWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const LogoImg = styled.img`
+  width: 150px;
+  height: 150px;
+`;
+
+const ClubTitle = styled.div`
+  font-size: 24px;
+  font-weight: bold;
+  padding: 5px 0;
+`;
+
+const ClubTopic = styled.div`
+  width: 150px;
+  display: flex;
+  text-align: center;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+`;
+
+const TopicTxt = styled.div`
+  padding: 0 5px;
+`;
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  cursor: pointer;
+  color: #27374d;
+  &:hover {
+    color: #526d82;
+  }
+`;
+
 const ClubItem = (data) => {
+  const field = useLocation().pathname.split("/")[2];
+
   return (
-    <div key={data._id}>
-      <img src={data.logoUrl} />
-      <div>{data.name}</div>
-      <div>
-        {data.topic.map((title) => (
-          <div>{title}</div>
-        ))}
-      </div>
-    </div>
+    <StyledLink to={`/area/${field}/${data.data._id}`}>
+      <CardItemWrap key={data.data._id}>
+        <LogoImg src={data.data.logoUrl} alt="이미지" />
+        <ClubTitle>{data.data.name}</ClubTitle>
+        <ClubTopic>
+          {data.data.topic.map((topic) => (
+            <TopicTxt key={topic}>{topic}</TopicTxt>
+          ))}
+        </ClubTopic>
+      </CardItemWrap>
+    </StyledLink>
   );
 };
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -15,6 +15,7 @@ import NotPage from "./pages/NotPage";
 import FindIdPage from "./pages/FindIdPage";
 import FindPwPage from "./pages/FindPwPage";
 import ResetPwPage from "./pages/ResetPwPage";
+import ClubPage from "./pages/ClubPage";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
@@ -27,6 +28,7 @@ root.render(
         <Route path="/find/id" element={<FindIdPage />} />
         <Route path="/find/password" element={<FindPwPage />} />
         <Route path="/area/:field" element={<AreaPage />} />
+        <Route path="/area/:field/:id" element={<ClubPage />} />
         <Route path="/intro" element={<IntroPage />} />
         <Route path="/input" element={<InputPage />} />
         <Route path="/mypage" element={<MyPage />} />

--- a/frontend/src/pages/ClubPage.jsx
+++ b/frontend/src/pages/ClubPage.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function ClubPage() {
+  return <>ClubPage</>;
+}
+
+export default ClubPage;


### PR DESCRIPTION
구현 내용
- 검색 페이지를 구현했습니다.
- 검색 결과 보이는 카드 아이템을 구현했습니다.
- 해당 카드 아이템을 클릭하면 해당 동아리 페이지로 이동합니다.
- 그리드는 5 x 무한대로 구성했습니다. 
- 주제가 많을 경우를 산정해 최대 2개만 보이고 나머지는 ...으로 표시했습니다.(보이는 ui만 제한, 기능이나 검색 로직과는 무방)



<img width="1222" alt="image" src="https://github.com/Lim-JiSeon/HufsClub/assets/83554018/c736222d-bd73-4bf4-a2a4-6cb872727fb0">
