### PR TITLE
동아리(글) 삭제 controller

### DIFF
--- a/backend/utili.js
+++ b/backend/utili.js
@@ -47,12 +47,4 @@ const isAdmin = (req, res, next) => {
   }
 };
 
-const isPresidentOrAdmin = (req, res, next) => {
-  if (req.user && (req.user.isPresident || req.user.isAdmin)) {
-    next();
-  } else {
-    res.status(401).send({ message: 'Invalid Manager Token' });
-  }
-};
-
-export { generateToken, isAuth, isAdmin, isPresidentOrAdmin, baseUrl };
+export { generateToken, isAuth, isAdmin, baseUrl };


### PR DESCRIPTION
- 동아리 글 삭제 controller 및 API 명세서 작성(해당 동아리 회장 또는 관리자인지는 프론트에서 검사해서 버튼을 띄움)
  해당 api에서 동아리(글)뿐만 아니라 모든 사용자의 좋아요 목록에서도 해당 동아리를 삭제하도록 작업했습니다.
  삭제 버튼을 누르면 바로 삭제되는 것이 아니라 "삭제하시겠습니까?"라고 물어보는 알림 창을 한 번 더 띄워주면 좋을 것 같아요!

저는 드디어 api작업을 모두 완료했습니다!
지선님 작업이 끝나면 배포 준비를 하면 좋을 것 같아요:)
저는 앞으로 수요일 9시까지 pull req를 올리지 않고 지선님이 수정해야 할 api나 새로 추가해야 할 api가 생기실 때마다 저한테 말씀해주시면 그때그때 작업 후 pull req를 올리도록 하겠습니다!