### PR TITLE
로그인 페이지 에러 수정

### DIFF
--- a/frontend/src/components/ClubGrid.js
+++ b/frontend/src/components/ClubGrid.js
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import ClubItem from "./func/ClubItem";
 
 const GridWrap = styled.div`
-  width: 90vw;
+  width: 70vw;
   height: 50vh;
   background-color: #ffffff;
   border-radius: 20px;
@@ -17,7 +17,7 @@ const GridWrap = styled.div`
 
 const ClubGrid = (data) => {
   const clubs = data.data.data;
- 
+
   return (
     <GridWrap>
       {clubs

--- a/frontend/src/components/LoginForm.js
+++ b/frontend/src/components/LoginForm.js
@@ -36,7 +36,7 @@ const LoginForm = ({ onSubmit }) => {
     validate: ({ id, password }) => {
       const newErrors = {};
       if (!id || id.length !== 9 || !checkNum.test(id))
-        newErrors.id = "올바른 아이디를 입력해주세요";
+        newErrors.id = "숫자 9자리를 입력해주세요";
       if (!password) newErrors.password = "비밀번호를 입력해주세요";
       return newErrors;
     },

--- a/frontend/src/components/MyContents.js
+++ b/frontend/src/components/MyContents.js
@@ -6,7 +6,7 @@ import LogoutButton from "./func/LogoutButton";
 import { useNavigate } from "react-router-dom";
 
 const ContentWrap = styled.div`
-  width: 90vw;
+  width: 70vw;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/club-detail/ClubContents.js
+++ b/frontend/src/components/club-detail/ClubContents.js
@@ -12,7 +12,7 @@ import { useNavigate } from "react-router-dom";
 import deleteClub from "../../api/deleteClub";
 
 const ContentWrap = styled.div`
-  width: 90vw;
+  width: 70vw;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -35,7 +35,7 @@ const DetailWrap = styled.div`
 
 const ButtonWrap = styled.div`
   display: flex;
-  width: 90vw;
+  width: 70vw;
   justify-content: flex-end;
   align-items: center;
   padding: 10px 0;

--- a/frontend/src/components/club-detail/ClubIntro.js
+++ b/frontend/src/components/club-detail/ClubIntro.js
@@ -14,12 +14,12 @@ const ImageWrap = styled.div`
 `;
 
 const ClubContent = styled.div`
+  width: 100%;
   color: #27374d;
   font-size: 14px;
   display: grid;
   grid-template-columns: repeat(1, 1fr);
   gap: 30px;
-  overflow: hidden;
 `;
 
 const ClubName = styled.div`
@@ -38,7 +38,6 @@ const ClubRoom = styled.div`
 
 const TopicWrap = styled.div`
   width: fit-content;
-  width: 90vw;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -51,9 +50,14 @@ const TopicText = styled.div`
   padding-right: 20px;
 `;
 
+const ClubIntroContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
 const ClubIntro = (data) => {
   const { logoUrl, name, topic } = data.data;
-
+  
   return (
     <ContentWrap>
       <ImageWrap>
@@ -62,7 +66,7 @@ const ClubIntro = (data) => {
       <ClubContent>
         <ClubName>{name}</ClubName>
         <ClubRoom>{tempData.room}</ClubRoom>
-        <div>{tempData.intro}</div>
+        <ClubIntroContainer>{tempData.intro}</ClubIntroContainer>
         <TopicWrap>
           {topic.map((title) => (
             <TopicText key={title}>{title}</TopicText>

--- a/frontend/src/components/club-detail/ClubJoin.js
+++ b/frontend/src/components/club-detail/ClubJoin.js
@@ -33,13 +33,13 @@ const BoxDiv = styled.div`
 
 const ContentsDiv = styled.div`
   color: #27374d;
-  font-weight: bold;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 60px;
 `;
 
 const SubTitleText = styled.div`
+  font-weight: bold;
   font-size: 22px;
   padding: 15px 0 50px 0;
 `;

--- a/frontend/src/components/club-edit/ClubIntro.js
+++ b/frontend/src/components/club-edit/ClubIntro.js
@@ -38,7 +38,7 @@ const ClubRoom = styled.div`
 
 const TopicWrap = styled.div`
   width: fit-content;
-  width: 90vw;
+  width: 70vw;
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/frontend/src/components/club-edit/EditClubContents.js
+++ b/frontend/src/components/club-edit/EditClubContents.js
@@ -9,7 +9,7 @@ import ClubJoin from "./ClubJoin";
 import { useNavigate } from "react-router-dom";
 
 const ContentWrap = styled.div`
-  width: 90vw;
+  width: 70vw;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/hooks/useForm.js
+++ b/frontend/src/hooks/useForm.js
@@ -36,7 +36,9 @@ const useForm = ({ initialValues, onSubmit, validate }) => {
         sessionStorage.setItem("hufs-password", values.password);
         navigate("/");
       } catch (error) {
-        alert("올바른 아이디와 비밀번호를 입력해주세요.");
+        alert(
+          "사용자를 찾을 수 없습니다.\n올바른 아이디와 비밀번호를 입력해주세요."
+        );
       }
     }
     setErrors(newErrors);

--- a/frontend/src/pages/AreaPage.jsx
+++ b/frontend/src/pages/AreaPage.jsx
@@ -16,14 +16,14 @@ const AreaContainer = styled.div`
 `;
 
 const Banner = styled.img`
-  width: 90vw;
+  width: 75vw;
   height: 300px;
   border-radius: 10px;
   border: none;
 `;
 
 const ButtonWrap = styled.div`
-  width: 90vw;
+  width: 70vw;
   height: 40px;
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
로그인 페이지 팝업창 내용을 수정했습니다.
- 아이디(학번) 입력시 숫자 9자리가 아닐 경우에는 빨간색 글씨로 입력 창 아래에 숫자 9자리를 입력해달라고 validation check를 했습니다.
- 팝업창 같은 경우는 아이디와 비밀번호를 모두 입력한 뒤 로그인하기 버튼을 클릭할 경우에만 뜨며, 가입된 아이디가 아닐 경우, 아이디와 비밀번호가 일치하지 않을 경우 즉 login api를 호출했을 때 에러를 반환해주는 경우를 모두 고려해 가입된 유저가 아니며, 올바른 아이디와 비밀번호를 입력하란 메시지로 수정했습니다.(use not find 경우 등)

그 외 회의 때 수정했던 90vw 비율을 70vw로 줄이는 코드가 추가되었습니다.(width 길이 수정)

## 이슈 번호
- close #49  