### PR TITLE
아이디 찾기 페이지 에러 수정

### DIFF
--- a/frontend/src/api/findId.js
+++ b/frontend/src/api/findId.js
@@ -2,15 +2,20 @@ import axios from "axios";
 
 const findId = (name, email) => {
   const API_END_POINT = "http://localhost:5000/api/";
-
-  try {
-    axios.post(`${API_END_POINT}users/forget-id`, {
-      username: name,
-      email: email,
-    });
-    alert("입력하신 이메일로 인증번호를 보냈습니다.");
-  } catch (error) {
-    alert("회원을 찾을 수 없습니다.");
+  if (name && email) {
+    axios
+      .post(`${API_END_POINT}users/forget-id`, {
+        username: name,
+        email: email,
+      })
+      .then(() => {
+        alert("입력하신 이메일로 인증번호를 보냈습니다.");
+      })
+      .catch(() => {
+        alert("회원을 찾을 수 없습니다.");
+      });
+  } else {
+    alert("이름과 이메일을 모두 입력해주세요.");
   }
 };
 

--- a/frontend/src/hooks/useForm.js
+++ b/frontend/src/hooks/useForm.js
@@ -76,12 +76,12 @@ const useForm = ({ initialValues, onSubmit, validate }) => {
     e.preventDefault();
     const newErrors = validate(values);
     if (Object.keys(newErrors).length === 0) {
-      try {
-        const response = await getId(values.email, values.verificationCode);
+      const response = await getId(values.email, values.verificationCode);
+      if (response.studentId) {
         alert(`아이디는 ${response.studentId} 입니다.`);
         navigate("/login");
-      } catch (error) {
-        alert("회원을 찾을 수 없습니다.");
+      } else {
+        alert("인증번호가 올바르지 않습니다.");
       }
     }
     setErrors(newErrors);


### PR DESCRIPTION
- 이름, 이메일을 입력하지 않고, 인증번호 발송 버튼을 클릭할 경우 api를 호출하지 않고 필수 입력란들을 입력해달라는 팝업창을 띄웁니다.
- 이름과 이메일을 입력한 뒤 인증번호 발송 버튼을 클릭할 때 만약 가입된 이메일이 아니라면 회원을 찾을 수 없다는 팝업창이 나옵니다.
- 잘못된 인증번호를 입력한 뒤 아이디 찾기 버튼을 클릭하면 올바른 인증 번호를 입력하라는 팝업창이 나옵니다.(화면 이동하지 않음)

## 이슈 번호
- close #54 