### PR TITLE
비밀번호 찾기 페이지 에러 수정

### DIFF
--- a/frontend/src/api/findPw.js
+++ b/frontend/src/api/findPw.js
@@ -3,16 +3,18 @@ import axios from "axios";
 const findPw = async (email) => {
   const API_END_POINT = "http://localhost:5000/api/";
 
-  try {
-    axios.post(`${API_END_POINT}users/forget-password`, {
+  axios
+    .post(`${API_END_POINT}users/forget-password`, {
       email: email,
+    })
+    .then(() => {
+      alert(
+        "입력하신 이메일로 새로운 비밀번호를 설정할 수 있는 링크를 보냈습니다."
+      );
+    })
+    .catch(() => {
+      alert("회원을 찾을 수 없습니다.");
     });
-    alert(
-      "입력하신 이메일로 새로운 비밀번호를 설정할 수 있는 링크를 보냈습니다."
-    );
-  } catch (error) {
-    alert("회원을 찾을 수 없습니다.");
-  }
 };
 
 export default findPw;

--- a/frontend/src/components/FindPwForm.js
+++ b/frontend/src/components/FindPwForm.js
@@ -14,7 +14,7 @@ const FindPwForm = ({ onSubmit }) => {
     validate: ({ email }) => {
       const newErrors = {};
       if (!email)
-        newErrors.email = "필수 입력란입니다. 올바른 이메일을 입력해주세요.";
+        newErrors.email = "올바른 이메일을 입력해주세요.";
       return newErrors;
     },
   });


### PR DESCRIPTION
- 가입된 이메일이 아닌 다른 이메일을 입력했을 경우 회원을 찾을 수 없다는 내용의 팝업창을 보여줍니다. 