### PR TITLE
분야별로 검색되도록 수정

### DIFF
--- a/backend/routes/clubRoutes.js
+++ b/backend/routes/clubRoutes.js
@@ -27,10 +27,11 @@ clubRouter.get('/field/:field', async (req, res) => {
 
 //동아리명 검색
 clubRouter.get('/search', async (req, res) => {
-  const { keyword } = req.query;
+  const { field, keyword } = req.query;
   let clubs = [];
   if (keyword) {
     clubs = await Club.find({
+      field: field,
       name: {
         $regex: new RegExp(keyword, "i"),
       },
@@ -41,10 +42,11 @@ clubRouter.get('/search', async (req, res) => {
 
 //동아리 주제 검색
 clubRouter.get('/search/topic', async (req, res) => {
-  const { keyword } = req.query;
+  const { field, keyword } = req.query;
   let clubs = [];
   if (keyword) {
     clubs = await Club.find({
+      field: field,
       topic: {
         $regex: new RegExp(keyword, "i"),
       },
@@ -55,11 +57,12 @@ clubRouter.get('/search/topic', async (req, res) => {
 
 //동아리 활동 검색
 clubRouter.get('/search/activity', async (req, res) => {
-  const { keyword } = req.query;
+  const { field, keyword } = req.query;
   let clubs = [];
   if (keyword) {
     clubs = await Club.find({
-        'activity.text': { $regex: new RegExp(keyword, "i"),
+      field: field,
+      'activity.text': { $regex: new RegExp(keyword, "i"),
       },
     });
   }


### PR DESCRIPTION
<검색(동아리 조회)>
- 검색 로직 분야별로 검색되도록 수정

<동아리 상세 페이지>
- 명세서에는 room이 있는데 room data가 안 온다.
   => room은 필수 정보가 아니므로 room정보가 없는 동아리가 있습니다.  room data를 가지고 있는 PnP를 확인해보면 room data가 잘 오는 것을 확인했습니다!

## 이슈 번호
- close #60 